### PR TITLE
fix: pin versions of python packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+algoliasearch==3.0.0
+bs4==0.0.2
+docopt==0.6.2
+fluent-discourse==1.0.1

--- a/setup
+++ b/setup
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-pip3 install \
-    algoliasearch \
-    bs4 \
-    docopt \
-    fluent-discourse \
+pip3 install -r requirements.txt
 
 chmod +x \
     main-etl \


### PR DESCRIPTION
# Problem

This broke when algolia upgraded from 3.0.0 to 4.0.0.

# Solution

Pin versions of our python dependencies.
